### PR TITLE
Introduce Data Model for Entities

### DIFF
--- a/lib/poa_agent/entity.ex
+++ b/lib/poa_agent/entity.ex
@@ -1,0 +1,16 @@
+defmodule POAAgent.Entity do
+  @moduledoc false
+
+  defmodule Name do
+    @moduledoc false
+
+    def change({old, new}, data) do
+      {value, data} = Map.pop(data, old)
+      Map.put(data, new, value)
+    end
+  end
+
+  defprotocol NameConvention do
+    def from_elixir_to_node(x)
+  end
+end

--- a/lib/poa_agent/entity/ethereum/block.ex
+++ b/lib/poa_agent/entity/ethereum/block.ex
@@ -1,6 +1,52 @@
 defmodule POAAgent.Entity.Ethereum.Block do
+  @moduledoc false
+  alias POAAgent.Format.Literal
+
   @type t :: %__MODULE__{
+    author: Literal.Hex.t(),
+    difficulty: Literal.Decimal.t(),
+    extra_data: Literal.Hex.t(),
+    gas_limit: non_neg_integer,
+    gas_used: non_neg_integer,
+    hash: Literal.Hex.t(),
+    miner: Literal.Hex.t(),
+    number: non_neg_integer,
+    parent_hash: Literal.Hex.t(),
+    receipts_root: Literal.Hex.t(),
+    seal_fields: [Literal.Hex.t()|[Literal.Hex.t]],
+    sha3_uncles: Literal.Hex.t(),
+    signature: Literal.TrimmedHex.t(),
+    size: non_neg_integer,
+    state_root: Literal.Hex.t(),
+    step: Literal.Decimal.t(),
+    timestamp: pos_integer,
+    total_difficulty: Literal.Decimal.t(),
+    transactions: [term],
+    transactions_root: Literal.Hex.t(),
+    uncles: [term]
   }
+
   defstruct [
+    :author,
+    :difficulty,
+    :extra_data,
+    :gas_limit,
+    :gas_used,
+    :hash,
+    :miner,
+    :number,
+    :parent_hash,
+    :receipts_root,
+    :seal_fields,
+    :sha3_uncles,
+    :signature,
+    :size,
+    :state_root,
+    :step,
+    :timestamp,
+    :total_difficulty,
+    :transactions,
+    :transactions_root,
+    :uncles
   ]
 end

--- a/lib/poa_agent/entity/ethereum/block.ex
+++ b/lib/poa_agent/entity/ethereum/block.ex
@@ -49,4 +49,22 @@ defmodule POAAgent.Entity.Ethereum.Block do
     :transactions_root,
     :uncles
   ]
+
+  defimpl POAAgent.Entity.NameConvention do
+    def from_elixir_to_node(x) do
+      mapping = [
+        extra_data: :extraData,
+        gas_limit: :gasLimit,
+        gas_used: :gasUsed,
+        parent_hash: :parentHash,
+        receipts_root: :receiptsRoot,
+        seal_fields: :sealFields,
+        sha3_uncles: :sha3Uncles,
+        state_root: :stateRoot,
+        total_difficulty: :totalDifficulty,
+        transactions_root: :transactionsRoot
+      ]
+      Enum.reduce(mapping, x, &POAAgent.Entity.Name.change/2)
+    end
+  end
 end

--- a/lib/poa_agent/entity/ethereum/block.ex
+++ b/lib/poa_agent/entity/ethereum/block.ex
@@ -1,0 +1,6 @@
+defmodule POAAgent.Entity.Ethereum.Block do
+  @type t :: %__MODULE__{
+  }
+  defstruct [
+  ]
+end

--- a/lib/poa_agent/entity/ethereum/history.ex
+++ b/lib/poa_agent/entity/ethereum/history.ex
@@ -1,3 +1,5 @@
 defmodule POAAgent.Entity.Ethereum.History do
-  @type t :: [POAAgent.Entity.Ethereum.Block.t]
+  @moduledoc false
+
+  @type t :: [POAAgent.Entity.Ethereum.Block.t()]
 end

--- a/lib/poa_agent/entity/ethereum/history.ex
+++ b/lib/poa_agent/entity/ethereum/history.ex
@@ -1,0 +1,3 @@
+defmodule POAAgent.Entity.Ethereum.History do
+  @type t :: [POAAgent.Entity.Ethereum.Block.t]
+end

--- a/lib/poa_agent/entity/ethereum/statistics.ex
+++ b/lib/poa_agent/entity/ethereum/statistics.ex
@@ -1,6 +1,28 @@
 defmodule POAAgent.Entity.Ethereum.Statistics do
+  @moduledoc false
+  alias POAAgent.Format.Literal
+
   @type t :: %__MODULE__{
+    active?: boolean,
+    mining?: boolean,
+    hashrate: non_neg_integer,
+    peers: non_neg_integer,
+    pending: non_neg_integer,
+    gas_price: Literal.Decimal.t(),
+    block: POAAgent.Entity.Ethereum.Block.t(),
+    syncing?: boolean,
+    uptime: non_neg_integer
   }
+
   defstruct [
+    :active?,
+    :mining?,
+    :hashrate,
+    :peers,
+    :pending,
+    :gas_price,
+    :block,
+    :syncing?,
+    :uptime
   ]
 end

--- a/lib/poa_agent/entity/ethereum/statistics.ex
+++ b/lib/poa_agent/entity/ethereum/statistics.ex
@@ -1,0 +1,6 @@
+defmodule POAAgent.Entity.Ethereum.Statistics do
+  @type t :: %__MODULE__{
+  }
+  defstruct [
+  ]
+end

--- a/lib/poa_agent/entity/ethereum/statistics.ex
+++ b/lib/poa_agent/entity/ethereum/statistics.ex
@@ -15,14 +15,27 @@ defmodule POAAgent.Entity.Ethereum.Statistics do
   }
 
   defstruct [
-    :active?,
-    :mining?,
-    :hashrate,
-    :peers,
-    :pending,
-    :gas_price,
-    :block,
-    :syncing?,
-    :uptime
+    active?: nil,
+    mining?: nil,
+    hashrate: nil,
+    peers: nil,
+    pending: nil,
+    gas_price: nil,
+    block: %POAAgent.Entity.Ethereum.Block{},
+    syncing?: nil,
+    uptime: nil
   ]
+
+  defimpl POAAgent.Entity.NameConvention do
+    def from_elixir_to_node(x) do
+      mapping = [
+        active?: :active,
+        mining?: :mining,
+        gas_price: :gasPrice,
+        syncing?: :syncing
+      ]
+      x = Enum.reduce(mapping, x, &POAAgent.Entity.Name.change/2)
+      Map.update!(x, :block, &POAAgent.Entity.NameConvention.from_elixir_to_node/1)
+    end
+  end
 end

--- a/lib/poa_agent/entity/host/information.ex
+++ b/lib/poa_agent/entity/host/information.ex
@@ -31,4 +31,13 @@ defmodule POAAgent.Entity.Host.Information do
     :client,
     :can_update_history?
   ]
+
+  defimpl POAAgent.Entity.NameConvention do
+    def from_elixir_to_node(x) do
+      mapping = [
+        can_update_history?: :canUpdateHistory
+      ]
+      Enum.reduce(mapping, x, &POAAgent.Entity.Name.change/2)
+    end
+  end
 end

--- a/lib/poa_agent/entity/host/information.ex
+++ b/lib/poa_agent/entity/host/information.ex
@@ -1,6 +1,34 @@
 defmodule POAAgent.Entity.Host.Information do
+  @moduledoc false
+  alias POAAgent.Format.Literal
+
   @type t :: %__MODULE__{
+    name: String.t(),
+    contact: URI.t(),
+    coinbase: Literal.Hex.t(),
+    node: String.t(),
+    net: Literal.Decimal.t(),
+    protocol: pos_integer,
+    api: Version.t(),
+    port: Literal.Decimal.t(), ## :inet.port_number()
+    os: String.t(),
+    os_v: Version.t(),
+    client: Version.t(),
+    can_update_history?: boolean
   }
+
   defstruct [
+    :name,
+    :contact,
+    :coinbase,
+    :node,
+    :net,
+    :protocol,
+    :api,
+    :port,
+    :os,
+    :os_v,
+    :client,
+    :can_update_history?
   ]
 end

--- a/lib/poa_agent/entity/host/information.ex
+++ b/lib/poa_agent/entity/host/information.ex
@@ -1,0 +1,6 @@
+defmodule POAAgent.Entity.Host.Information do
+  @type t :: %__MODULE__{
+  }
+  defstruct [
+  ]
+end

--- a/lib/poa_agent/format.ex
+++ b/lib/poa_agent/format.ex
@@ -1,0 +1,29 @@
+defmodule POAAgent.Format do
+  @moduledoc false
+
+  defmodule Literal do
+    @moduledoc false
+
+    defmodule Hex do
+      @moduledoc false
+
+      ## A literal hex string like "0x0123456789abcdef"
+      @type t :: String.t
+    end
+
+    defmodule TrimmedHex do
+      @moduledoc false
+
+      ## A literal hex string like "0123456789abcdef" w/o the leading
+      ## "0x" indicator
+      @type t :: String.t
+    end
+
+    defmodule Decimal do
+      @moduledoc false
+
+      ## A literal decimal string like "0123456789"
+      @type t :: String.t
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule POAAgent.MixProject do
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
+      dialyzer: dialyzer(),
       docs: docs()
     ]
   end
@@ -45,4 +46,11 @@ defmodule POAAgent.MixProject do
     ]
   end
 
+  defp dialyzer do
+    [
+      paths: [
+        "_build/#{Mix.env()}/lib/poa_agent/consolidated"
+      ]
+    ]
+  end
 end

--- a/test/poa_agent/entity_test.exs
+++ b/test/poa_agent/entity_test.exs
@@ -1,0 +1,24 @@
+defmodule POAAgent.EntityTest do
+  use ExUnit.Case
+
+  test "key transformation is Node/JS friendly" do
+    alias POAAgent.Entity.Host
+    alias POAAgent.Entity.Ethereum
+
+    good? = fn x ->
+      not String.contains?(x, ["_", "?"])
+    end
+    exception = "os_v"
+
+    x = [Host.Information, Ethereum.Block, Ethereum.Statistics]
+    |> Enum.map(&Kernel.struct/1)
+    |> Enum.map(&POAAgent.Entity.NameConvention.from_elixir_to_node/1)
+    |> Enum.map(&Map.from_struct/1)
+    |> Enum.map(&Map.keys/1)
+    |> List.flatten()
+    |> Enum.map(&Atom.to_string/1)
+    |> List.delete(exception)
+
+    assert Enum.all?(x, good?)
+  end
+end


### PR DESCRIPTION
This PR captures the entities the agent will be sending to the server along with their respective Dialyzer declarations.

A few notes:

1. The Elixir structs are a "superset" of what goes on the wire (i.e. some fields aren't sent over to the server)
2. The types for the fields are a mix of what they should be with what goes on the wire. If the types are more closely related with what goes on the wire then it's obvious because `Format.Literal.{Hex,TrimmedHex,Decimal}.t()` indicate that the field holds an integer value whose representation might matter
3. The field names follow **Elixir** convention (not Node/JS). There is a transformer protocol in `Entity.NameConvention` for camel casing, removing trailing `?`, and exceptions in some of the fields that the Node server sends over (e.g. `os_v`)